### PR TITLE
Adding dependency for playing mp3s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'junit:junit:4.13.1'
+    implementation 'junit:junit:4.13.1', 'javazoom:jlayer:1.0.1'
     testImplementation('org.junit.jupiter:junit-jupiter:5.9.0')
 }
 


### PR DESCRIPTION
Adding the JLayer dependency for playing mp3 files easily. See an example below (exceptions would need to be handled in practice, ofc):

```
import javazoom.jl.decoder.JavaLayerException;
import javazoom.jl.player.Player;
import java.io.File;
import java.io.FileInputStream;
import java.io.FileNotFoundException;

public class test {
    public static void main(String[] args) throws JavaLayerException, FileNotFoundException {
        File song = new File("./src/main/java/test.mp3"); // song object from songLibrary
        FileInputStream media = new FileInputStream(song);
        Player player = new Player(media);
        player.play();
    }
}
```

Make sure to merge this into your branches and update your Gradle builds if this merges.